### PR TITLE
Some changes to make single node work in a portable manner. Hardcoded name…

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -1,7 +1,10 @@
 project:
   name: quickstart-tableau-server
   owner: quickstart-eng@amazon.com
-  s3_bucket: quickstart-testing-public
+  s3_bucket: ''
+  package_lambda: false
+  s3_regional_buckets: true
+  shorten_stack_name: true
   regions:
   - us-west-2
   tags:
@@ -18,19 +21,19 @@ tests:
       OS: Linux
       Route53HostedZone: Z03034441712JY0KSJGD1
       Route53DomainName: awsquickstart.tableau.com
-      S3BucketName: tableau-server-data-bucket2
+      S3BucketName: tableau-data-$[taskcat_random-string]
       AcceptEULA: 'yes'
       InstanceType: m6i.4xlarge
-      KeyPairName: takashi-quickstart
+      KeyPairName: $[taskcat_getkeypair]
       LatestAmiId: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
-      TableauServerAdminPassword: $[alfred_genpass_32]
+      TableauServerAdminPassword: $[taskcat_genpass_32]
       TableauServerAdminUser: admin
       LicenseKey: ''
       TsmUsername: tsmadmin
-      TsmPassword: $[alfred_genpass_32]
-      QSS3BucketName: quickstart-testing-public
+      TsmPassword: $[taskcat_genpass_32]
+      QSS3BucketName: $[taskcat_autobucket]
       QSS3KeyPrefix: quickstart-tableau-server/
-      QSS3BucketRegion: us-west-2
+      QSS3BucketRegion: $[taskcat_current_region]
       RegCity: Test City
       RegCompany: Test Company
       RegCountry: Test Country
@@ -44,34 +47,34 @@ tests:
       RegTitle: Test Title
       RegZip: Test Zip
     template: templates/parent-stack.template
-  windows:
-    parameters: 
-      OS: Windows
-      Route53HostedZone: Z03034441712JY0KSJGD1
-      Route53DomainName: awsquickstart.tableau.com
-      S3BucketName: tableau-server-data-bucket2
-      AcceptEULA: 'yes'
-      InstanceType: m6i.4xlarge
-      KeyPairName: takashi-quickstart
-      LatestAmiId: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
-      TableauServerAdminPassword: $[alfred_genpass_32]
-      TableauServerAdminUser: admin
-      LicenseKey: ''
-      TsmUsername: tsmadmin
-      TsmPassword: $[alfred_genpass_32]
-      QSS3BucketName: quickstart-testing-public
-      QSS3KeyPrefix: quickstart-tableau-server/
-      QSS3BucketRegion: us-west-2
-      RegCity: Test City
-      RegCompany: Test Company
-      RegCountry: Test Country
-      RegDepartment: Test Department
-      RegEmail: testemail@example.com
-      RegFirstName: Test First Name
-      RegIndustry: Test Industry
-      RegLastName: Test Last Name
-      RegPhone: Test Phone
-      RegState: Test State
-      RegTitle: Test Title
-      RegZip: Test Zip
-    template: templates/parent-stack.template
+#  windows:
+#    parameters:
+#      OS: Windows
+#      Route53HostedZone: Z03034441712JY0KSJGD1
+#      Route53DomainName: awsquickstart.tableau.com
+#      S3BucketName: tableau-server-data-bucket2
+#      AcceptEULA: 'yes'
+#      InstanceType: m6i.4xlarge
+#      KeyPairName: takashi-quickstart
+#      LatestAmiId: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+#      TableauServerAdminPassword: $[alfred_genpass_32]
+#      TableauServerAdminUser: admin
+#      LicenseKey: ''
+#      TsmUsername: tsmadmin
+#      TsmPassword: $[alfred_genpass_32]
+#      QSS3BucketName: quickstart-testing-public
+#      QSS3KeyPrefix: quickstart-tableau-server/
+#      QSS3BucketRegion: us-west-2
+#      RegCity: Test City
+#      RegCompany: Test Company
+#      RegCountry: Test Country
+#      RegDepartment: Test Department
+#      RegEmail: testemail@example.com
+#      RegFirstName: Test First Name
+#      RegIndustry: Test Industry
+#      RegLastName: Test Last Name
+#      RegPhone: Test Phone
+#      RegState: Test State
+#      RegTitle: Test Title
+#      RegZip: Test Zip
+#    template: templates/parent-stack.template

--- a/templates/child-infrastructure.template
+++ b/templates/child-infrastructure.template
@@ -36,6 +36,11 @@ Parameters:
   Route53DomainName:
     Description: Domain name for your Route53 Hosted Zone
     Type: String
+  SourceCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    Description: The CIDR address from which you will connect to the instance
+    Type: String
   S3BucketName:
     Description: S3 bucket to Tableau Server files
     Type: String
@@ -149,11 +154,11 @@ Resources:
             - CidrIp: "0.0.0.0/0"
               IpProtocol: "-1"
         SecurityGroupIngress: 
-            - CidrIp: "0.0.0.0/0"
+            - CidrIp: !Ref SourceCIDR
               FromPort: "80"
               ToPort: "80"
               IpProtocol: "tcp"
-            - CidrIp: "0.0.0.0/0"
+            - CidrIp: !Ref SourceCIDR
               FromPort: "443"
               ToPort: "443"
               IpProtocol: "tcp"
@@ -171,15 +176,13 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !Ref SecurityGroup
-      CidrIp: "192.195.4.0/24"
+      CidrIp: !Ref SourceCIDR
       IpProtocol: "tcp"
       FromPort: "3389"
       ToPort: "3389"
       Description: "RDP"
-  S3Bucket:
+  TableauS3Bucket:
     Type: 'AWS::S3::Bucket'
-    Properties:
-      BucketName: !Ref S3BucketName
   TableauIAMRole:
     Type: AWS::IAM::Role
     Properties:
@@ -205,8 +208,8 @@ Resources:
                 - s3:PutObject
                 - s3:ListBucket
               Resource:
-                - !Sub 'arn:aws:s3:::${S3BucketName}'
-                - !Sub 'arn:aws:s3:::${S3BucketName}/*'
+                - !Sub 'arn:aws:s3:::${TableauS3Bucket}'
+                - !Sub 'arn:aws:s3:::${TableauS3Bucket}/*'
               Effect: Allow
         PolicyName: back-to-s3
       - PolicyDocument:

--- a/templates/child-tableau-server-linux.template
+++ b/templates/child-tableau-server-linux.template
@@ -301,6 +301,8 @@ Resources:
                 zip: !Ref 'RegZip'
                 country: !Ref 'RegCountry'
                 eula: !Ref 'AcceptEULA'
+                company_employees: "5"
+                opt_in: "No"
             /tmp/config.json:
               content:
                 configEntities:
@@ -312,7 +314,6 @@ Resources:
                   identityStore:
                     _type: identityStoreType
                     type: local
-                topologyVersion: {}
             /tmp/tableau-server.rpm:
               source: !FindInMap
                 - DefaultConfiguration

--- a/templates/parent-stack.template
+++ b/templates/parent-stack.template
@@ -160,6 +160,11 @@ Parameters:
   QSS3KeyPrefix: 
     Description: Prefix for quickstart files in S3 bucket
     Type: String
+  SourceCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    Description: The CIDR address from which you will connect to the instance
+    Type: String
   RegCity:
     Description: City
     Type: String
@@ -201,9 +206,11 @@ Parameters:
     Type: String
 Mappings:
   Names:
+    #TODO TableauServer and Tsm values should likely be user input or something dynamic such that multiple deployments can be repeatedly done
     Route53:
       TableauServer: tableau
       Tsm: tsm
+    #TODO Same issue here, this will probably cause an error if you tried to have more than one stack in a Region.
     CloudWatch:
       TableauServerLogGroup: TableauServerLogs
       QuickstartLogGroup: TableauQuickstartSetup
@@ -226,6 +233,7 @@ Resources:
         Route53HostedZone: !Ref 'Route53HostedZone'
         Route53DomainName: !Ref 'Route53DomainName'
         S3BucketName: !Ref 'S3BucketName'
+        SourceCIDR: !Ref 'SourceCIDR'
         TableauServerSubdomain: !FindInMap ["Names", "Route53", "TableauServer"]
         TsmSubdomain: !FindInMap ["Names", "Route53", "Tsm"]
         TableauServerLogGroup: !FindInMap ["Names", "CloudWatch", "TableauServerLogGroup"]


### PR DESCRIPTION
Some changes to make single node work in a portable manner. Hardcoded names in mappings needs to be removed and instead autogenerated names can be used.

* We can't accept a default ingress from "0.0.0.0/0", I've replaced that back with SourceCIDR parameter.
* Renamed S3Bucket to TableauS3Bucket to be more descriptive.
* Updated .taskcat.yml 
* I got an error when using the generated registration.json. The error stated that company_employees and opt_in fields are missing, so I've just hard-coded it to "5", "No", please check if there is a better way.
* I also got an error in the config.json file that topology can't be created before the server is initialized. So I removed the `topologyVersion: {}` entry in config.json. Let me know what's the right approach here.